### PR TITLE
Add SQLite session logging to relay server

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -9,6 +9,7 @@ require (
 	github.com/schollz/progressbar/v3 v3.18.0
 	github.com/spf13/cobra v1.10.1
 	google.golang.org/protobuf v1.36.10
+	modernc.org/sqlite v1.34.4
 	rsc.io/qr v0.2.0
 )
 

--- a/integration_test.go
+++ b/integration_test.go
@@ -60,7 +60,7 @@ func TestIntegrationFileTransfer(t *testing.T) {
 
 	// Start the actual relay server in background
 	go func() {
-		relay.Start(port, 0, 0, staticFS, logger) // 0 limits disable room caps for integration tests
+		relay.Start(port, 0, 0, "", staticFS, logger) // 0 limits disable room caps for integration tests
 	}()
 
 	// Give the server time to start
@@ -203,7 +203,7 @@ func TestIntegrationFolderTransfer(t *testing.T) {
 
 	// Start the actual relay server in background
 	go func() {
-		relay.Start(port, 0, 0, staticFS, logger) // 0 limits disable room caps for integration tests
+		relay.Start(port, 0, 0, "", staticFS, logger) // 0 limits disable room caps for integration tests
 	}()
 
 	// Give the server time to start
@@ -352,7 +352,7 @@ func TestIntegrationHashVerification(t *testing.T) {
 
 	// Start the actual relay server in background
 	go func() {
-		relay.Start(port, 0, 0, staticFS, logger)
+		relay.Start(port, 0, 0, "", staticFS, logger)
 	}()
 
 	// Give the server time to start

--- a/main.go
+++ b/main.go
@@ -56,8 +56,9 @@ var serveCmd = &cobra.Command{
 		port, _ := cmd.Flags().GetInt("port")
 		maxRooms, _ := cmd.Flags().GetInt("max-rooms")
 		maxRoomsPerIP, _ := cmd.Flags().GetInt("max-rooms-per-ip")
+		dbPath, _ := cmd.Flags().GetString("db-path")
 		logger := createLogger(logLevel)
-		relay.Start(port, maxRooms, maxRoomsPerIP, staticFS, logger)
+		relay.Start(port, maxRooms, maxRoomsPerIP, dbPath, staticFS, logger)
 	},
 }
 
@@ -171,6 +172,7 @@ func init() {
 	serveCmd.Flags().IntP("port", "p", 3001, "Port to listen on")
 	serveCmd.Flags().Int("max-rooms", 10, "Maximum number of concurrent rooms allowed on the server")
 	serveCmd.Flags().Int("max-rooms-per-ip", 2, "Maximum number of rooms per IP address")
+	serveCmd.Flags().String("db-path", "relay_logs.db", "Path to SQLite database for session logging (empty to disable)")
 	sendCmd.Flags().StringP("server", "s", "", "Server URL (overrides --domain)")
 	receiveCmd.Flags().StringP("server", "s", "", "Server URL (overrides --domain)")
 	receiveCmd.Flags().StringP("output", "o", ".", "Output directory")

--- a/src/relay/database.go
+++ b/src/relay/database.go
@@ -1,0 +1,202 @@
+package relay
+
+import (
+	"database/sql"
+	"fmt"
+	"log/slog"
+	"sync"
+	"time"
+
+	_ "modernc.org/sqlite"
+)
+
+// SessionLog represents a relay session in the database
+type SessionLog struct {
+	SessionID      string
+	IPFrom         string
+	IPTo           string
+	BandwidthBytes int64
+	SessionStart   time.Time
+	SessionEnd     *time.Time
+}
+
+// Database handles SQLite operations for relay session logging
+type Database struct {
+	db     *sql.DB
+	logger *slog.Logger
+	mutex  sync.Mutex
+}
+
+var (
+	database     *Database
+	databaseOnce sync.Once
+)
+
+// InitDatabase initializes the SQLite database for session logging
+func InitDatabase(dbPath string, log *slog.Logger) error {
+	var err error
+	databaseOnce.Do(func() {
+		database = &Database{
+			logger: log,
+		}
+
+		database.db, err = sql.Open("sqlite", dbPath)
+		if err != nil {
+			err = fmt.Errorf("failed to open database: %w", err)
+			return
+		}
+
+		// Create the logs table if it doesn't exist
+		createTableSQL := `
+		CREATE TABLE IF NOT EXISTS logs (
+			session_id TEXT PRIMARY KEY,
+			ip_from TEXT NOT NULL,
+			ip_to TEXT,
+			bandwidth_bytes INTEGER DEFAULT 0,
+			session_start DATETIME NOT NULL,
+			session_end DATETIME
+		);
+
+		CREATE INDEX IF NOT EXISTS idx_session_start ON logs(session_start);
+		CREATE INDEX IF NOT EXISTS idx_ip_from ON logs(ip_from);
+		`
+
+		_, err = database.db.Exec(createTableSQL)
+		if err != nil {
+			err = fmt.Errorf("failed to create table: %w", err)
+			return
+		}
+
+		log.Info("Database initialized", "path", dbPath)
+	})
+
+	return err
+}
+
+// GetDatabase returns the singleton database instance
+func GetDatabase() *Database {
+	return database
+}
+
+// StartSession creates a new session log entry
+func (db *Database) StartSession(sessionID, ipFrom, ipTo string) error {
+	if db == nil || db.db == nil {
+		return fmt.Errorf("database not initialized")
+	}
+
+	db.mutex.Lock()
+	defer db.mutex.Unlock()
+
+	query := `
+		INSERT INTO logs (session_id, ip_from, ip_to, bandwidth_bytes, session_start)
+		VALUES (?, ?, ?, 0, ?)
+	`
+
+	_, err := db.db.Exec(query, sessionID, ipFrom, ipTo, time.Now())
+	if err != nil {
+		db.logger.Error("Failed to start session", "error", err, "session_id", sessionID)
+		return fmt.Errorf("failed to start session: %w", err)
+	}
+
+	db.logger.Debug("Session started", "session_id", sessionID, "ip_from", ipFrom, "ip_to", ipTo)
+	return nil
+}
+
+// UpdateBandwidth updates the bandwidth for a session
+func (db *Database) UpdateBandwidth(sessionID string, bytes int64) error {
+	if db == nil || db.db == nil {
+		return fmt.Errorf("database not initialized")
+	}
+
+	db.mutex.Lock()
+	defer db.mutex.Unlock()
+
+	query := `
+		UPDATE logs
+		SET bandwidth_bytes = bandwidth_bytes + ?
+		WHERE session_id = ?
+	`
+
+	_, err := db.db.Exec(query, bytes, sessionID)
+	if err != nil {
+		db.logger.Error("Failed to update bandwidth", "error", err, "session_id", sessionID)
+		return fmt.Errorf("failed to update bandwidth: %w", err)
+	}
+
+	return nil
+}
+
+// EndSession marks a session as ended
+func (db *Database) EndSession(sessionID string) error {
+	if db == nil || db.db == nil {
+		return fmt.Errorf("database not initialized")
+	}
+
+	db.mutex.Lock()
+	defer db.mutex.Unlock()
+
+	query := `
+		UPDATE logs
+		SET session_end = ?
+		WHERE session_id = ?
+	`
+
+	_, err := db.db.Exec(query, time.Now(), sessionID)
+	if err != nil {
+		db.logger.Error("Failed to end session", "error", err, "session_id", sessionID)
+		return fmt.Errorf("failed to end session: %w", err)
+	}
+
+	db.logger.Debug("Session ended", "session_id", sessionID)
+	return nil
+}
+
+// GetSessionStats retrieves session statistics
+func (db *Database) GetSessionStats(sessionID string) (*SessionLog, error) {
+	if db == nil || db.db == nil {
+		return nil, fmt.Errorf("database not initialized")
+	}
+
+	db.mutex.Lock()
+	defer db.mutex.Unlock()
+
+	query := `
+		SELECT session_id, ip_from, ip_to, bandwidth_bytes, session_start, session_end
+		FROM logs
+		WHERE session_id = ?
+	`
+
+	var log SessionLog
+	var sessionEnd sql.NullTime
+
+	err := db.db.QueryRow(query, sessionID).Scan(
+		&log.SessionID,
+		&log.IPFrom,
+		&log.IPTo,
+		&log.BandwidthBytes,
+		&log.SessionStart,
+		&sessionEnd,
+	)
+
+	if err != nil {
+		return nil, fmt.Errorf("failed to get session stats: %w", err)
+	}
+
+	if sessionEnd.Valid {
+		log.SessionEnd = &sessionEnd.Time
+	}
+
+	return &log, nil
+}
+
+// Close closes the database connection
+func (db *Database) Close() error {
+	if db == nil || db.db == nil {
+		return nil
+	}
+
+	db.mutex.Lock()
+	defer db.mutex.Unlock()
+
+	return db.db.Close()
+}


### PR DESCRIPTION
This commit adds persistent session logging to the relay server using modernc.org/sqlite. The database tracks relay sessions with the following information:

- session_id: Unique identifier for each client session
- ip_from: IP address of the connecting client
- ip_to: IP address of the primary peer in the room
- bandwidth_bytes: Total bytes relayed for this session
- session_start: Timestamp when the client joined
- session_end: Timestamp when the client disconnected

Key changes:
- Created src/relay/database.go with SQLite session logging functionality
- Added SessionStart, BytesRelayed, and PeerIPs fields to Client struct
- Updated relay handlers to log session start, end, and bandwidth
- Added --db-path flag to serve command (defaults to relay_logs.db)
- Updated relay.Start() signature to accept database path parameter
- IP addresses are properly extracted from X-Forwarded-For and X-Real-IP headers for use behind reverse proxies like Caddy

The database is optional and can be disabled by passing an empty string for the database path.