### PR TITLE
Add text color to connection and file transfer panels

### DIFF
--- a/web/src/App.jsx
+++ b/web/src/App.jsx
@@ -1480,7 +1480,7 @@ export default function App() {
 
                 {/* Connection Panel - only show on home page */}
                 {!pathRoom && (
-                    <div className="bg-gray-200 border-4 sm:border-8 border-black p-4 sm:p-6 mb-3 sm:mb-6 shadow-[4px_4px_0px_0px_rgba(0,0,0,1)] sm:shadow-[8px_8px_0px_0px_rgba(0,0,0,1)]">
+                    <div className="bg-gray-200 border-4 sm:border-8 border-black p-4 sm:p-6 mb-3 sm:mb-6 shadow-[4px_4px_0px_0px_rgba(0,0,0,1)] sm:shadow-[8px_8px_0px_0px_rgba(0,0,0,1)] text-gray-900">
                         {/* <h2 className="text-2xl sm:text-3xl font-black mb-3 sm:mb-4 uppercase">ROOM</h2> */}
                         <div className="flex flex-col sm:flex-row gap-3 sm:gap-4 mb-3 sm:mb-4">
                             <input
@@ -1547,7 +1547,7 @@ export default function App() {
 
                 {/* File Transfer Panel */}
                 {connected && (
-                    <div className="bg-gray-300 border-4 sm:border-8 border-black p-4 sm:p-6 mb-3 sm:mb-6 shadow-[4px_4px_0px_0px_rgba(0,0,0,1)] sm:shadow-[8px_8px_0px_0px_rgba(0,0,0,1)]">
+                    <div className="bg-gray-300 border-4 sm:border-8 border-black p-4 sm:p-6 mb-3 sm:mb-6 shadow-[4px_4px_0px_0px_rgba(0,0,0,1)] sm:shadow-[8px_8px_0px_0px_rgba(0,0,0,1)] text-gray-900">
                         {uploadProgress && (
                             <ProgressBar progress={uploadProgress} label={`Sending ${uploadProgress.fileName}`} />
                         )}


### PR DESCRIPTION
Fixes an issue with text not showing up on dark mode due to the default text color being white and the backgrounds also being white

### Before

<img width="912" height="427" alt="Screenshot 2025-11-06 at 14 12 57" src="https://github.com/user-attachments/assets/5223d750-bd83-494f-aee5-b19070bf6bec" />

### After

<img width="912" height="427" alt="Screenshot 2025-11-06 at 14 13 17" src="https://github.com/user-attachments/assets/74ef1de6-7171-4db6-bfda-fd5d5f9668db" />

Fixes #82 