### PR TITLE
Add text messaging functionality to e2ecp

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,8 @@
 module github.com/schollz/e2ecp
 
-go 1.25
+go 1.24.0
+
+toolchain go1.24.7
 
 require (
 	github.com/google/uuid v1.6.0

--- a/main.go
+++ b/main.go
@@ -63,12 +63,12 @@ var serveCmd = &cobra.Command{
 }
 
 var sendCmd = &cobra.Command{
-	Use:   "send <file-or-folder> [room]",
-	Short: "Send a file or folder to a room",
-	Long:  "Send a file or folder through E2E encryption to a specified room. Folders are automatically zipped for transfer.",
+	Use:   "send <file-or-folder-or-text> [room]",
+	Short: "Send a file, folder, or text to a room",
+	Long:  "Send a file, folder, or text message through E2E encryption to a specified room. Folders are automatically zipped for transfer. If the first argument is not a file or folder, it will be sent as text.",
 	Args:  cobra.RangeArgs(1, 2),
 	Run: func(cmd *cobra.Command, args []string) {
-		filePath := args[0]
+		input := args[0]
 		var roomID string
 		if len(args) >= 2 {
 			roomID = args[1]
@@ -80,7 +80,16 @@ var sendCmd = &cobra.Command{
 			server = getWebSocketURL(domain)
 		}
 		logger := createLogger(logLevel)
-		client.SendFile(filePath, roomID, server, logger)
+
+		// Check if input is a file or folder
+		_, err := os.Stat(input)
+		if err == nil {
+			// Path exists - send as file/folder
+			client.SendFile(input, roomID, server, logger)
+		} else {
+			// Path doesn't exist - send as text
+			client.SendText(input, roomID, server, logger)
+		}
 	},
 }
 

--- a/src/client/sendtext.go
+++ b/src/client/sendtext.go
@@ -7,6 +7,7 @@ import (
 	"log"
 	"log/slog"
 	"net/url"
+	"os"
 	"sync"
 	"time"
 
@@ -57,7 +58,9 @@ func SendText(text, roomID, serverURL string, logger *slog.Logger) {
 	// Show QR code
 	qrURL, _ := url.Parse(serverURL)
 	qrURL.Path = "/" + roomID
-	qrcode.PrintQRCode(qrURL.String())
+	if err := qrcode.PrintHalfBlock(os.Stdout, qrURL.String(), 15); err != nil {
+		logger.Debug("Failed to print QR code", "error", err)
+	}
 
 	fmt.Printf("Share this link with the recipient:\n")
 	fmt.Printf("  %s\n\n", qrURL.String())
@@ -98,7 +101,7 @@ func SendText(text, roomID, serverURL string, logger *slog.Logger) {
 				log.Fatalf("Failed to decode peer public key: %v", err)
 			}
 
-			peerPubKey, err := crypto.ParseECDHPublicKey(peerPubKeyBytes)
+			peerPubKey, err := ecdh.P256().NewPublicKey(peerPubKeyBytes)
 			if err != nil {
 				log.Fatalf("Failed to parse peer public key: %v", err)
 			}

--- a/src/client/sendtext.go
+++ b/src/client/sendtext.go
@@ -1,0 +1,158 @@
+package client
+
+import (
+	"crypto/ecdh"
+	"encoding/base64"
+	"fmt"
+	"log"
+	"log/slog"
+	"net/url"
+	"sync"
+	"time"
+
+	"github.com/schollz/e2ecp/src/crypto"
+	"github.com/schollz/e2ecp/src/qrcode"
+
+	"github.com/google/uuid"
+	"github.com/gorilla/websocket"
+)
+
+// SendText sends a text message to the specified room via the relay server
+func SendText(text, roomID, serverURL string, logger *slog.Logger) {
+	clientID := uuid.New().String()
+
+	privKey, err := crypto.GenerateECDHKeyPair()
+	if err != nil {
+		log.Fatalf("Failed to generate key pair: %v", err)
+	}
+
+	u, _ := url.Parse(serverURL)
+	u.Path = "/ws"
+	conn, _, err := websocket.DefaultDialer.Dial(u.String(), nil)
+	if err != nil {
+		log.Fatalf("Failed to connect: %v", err)
+	}
+	defer conn.Close()
+
+	// Mutex to protect websocket writes
+	var connMutex sync.Mutex
+	safeSend := func(msg map[string]interface{}) {
+		connMutex.Lock()
+		defer connMutex.Unlock()
+		sendProtobufMessage(conn, msg)
+	}
+
+	joinMsg := map[string]interface{}{
+		"type":     "join",
+		"roomId":   roomID,
+		"clientId": clientID,
+	}
+	safeSend(joinMsg)
+
+	// Generate random room if not provided
+	if roomID == "" {
+		log.Fatal("Room ID is required")
+	}
+
+	// Show QR code
+	qrURL, _ := url.Parse(serverURL)
+	qrURL.Path = "/" + roomID
+	qrcode.PrintQRCode(qrURL.String())
+
+	fmt.Printf("Share this link with the recipient:\n")
+	fmt.Printf("  %s\n\n", qrURL.String())
+	fmt.Printf("Waiting for peer to join room '%s'...\n", roomID)
+
+	// Handle incoming messages
+	var sharedSecret []byte
+	var myMnemonic string
+	var peerMnemonic string
+	peerConnected := false
+	textSent := false
+
+	for {
+		msg, err := receiveProtobufMessage(conn)
+		if err != nil {
+			logger.Debug("Connection closed", "error", err)
+			break
+		}
+
+		switch msg.Type {
+		case "joined":
+			myMnemonic = msg.Mnemonic
+			logger.Debug("Joined room", "mnemonic", myMnemonic)
+
+		case "peers":
+			if msg.Count >= 2 && !peerConnected {
+				fmt.Println("\nPeer connected! Establishing secure channel...")
+				peerConnected = true
+			}
+
+		case "pubkey":
+			peerMnemonic = msg.Mnemonic
+			logger.Debug("Received peer public key", "peer", peerMnemonic)
+
+			// Derive shared secret
+			peerPubKeyBytes, err := base64.StdEncoding.DecodeString(msg.Pub)
+			if err != nil {
+				log.Fatalf("Failed to decode peer public key: %v", err)
+			}
+
+			peerPubKey, err := crypto.ParseECDHPublicKey(peerPubKeyBytes)
+			if err != nil {
+				log.Fatalf("Failed to parse peer public key: %v", err)
+			}
+
+			sharedSecret, err = privKey.ECDH(peerPubKey)
+			if err != nil {
+				log.Fatalf("Failed to derive shared secret: %v", err)
+			}
+
+			// Announce our public key
+			pubBytes := privKey.PublicKey().Bytes()
+			pubKeyMsg := map[string]interface{}{
+				"type": "pubkey",
+				"pub":  base64.StdEncoding.EncodeToString(pubBytes),
+			}
+			safeSend(pubKeyMsg)
+
+			// Send text message
+			if sharedSecret != nil && !textSent {
+				textSent = true
+				err = sendTextMessage(text, sharedSecret, safeSend, logger)
+				if err != nil {
+					log.Fatalf("Failed to send text: %v", err)
+				}
+				fmt.Printf("\n✓ Sent text message to %s\n", peerMnemonic)
+				// Wait a bit to ensure message is delivered
+				time.Sleep(500 * time.Millisecond)
+				return
+			}
+
+		case "text_received":
+			// Receiver confirmed they received the text
+			fmt.Println("✓ Text message delivered")
+			return
+		}
+	}
+}
+
+func sendTextMessage(text string, sharedSecret []byte, safeSend func(map[string]interface{}), logger *slog.Logger) error {
+	// Encrypt the text message
+	textBytes := []byte(text)
+	iv, encryptedText, err := crypto.EncryptAESGCM(sharedSecret, textBytes)
+	if err != nil {
+		return fmt.Errorf("failed to encrypt text: %v", err)
+	}
+
+	// Send text_message with encrypted text
+	textMsg := map[string]interface{}{
+		"type":               "text_message",
+		"encrypted_metadata": base64.StdEncoding.EncodeToString(encryptedText),
+		"metadata_iv":        base64.StdEncoding.EncodeToString(iv),
+	}
+	safeSend(textMsg)
+
+	logger.Debug("Sent encrypted text message")
+	return nil
+}

--- a/tests/cli-to-web-text.spec.js
+++ b/tests/cli-to-web-text.spec.js
@@ -1,0 +1,131 @@
+// @ts-check
+const { test, expect } = require('@playwright/test');
+const path = require('path');
+const { spawn } = require('child_process');
+
+/**
+ * Test: CLI to Web text message transfer
+ *
+ * This test verifies that a text message can be successfully sent from the command-line
+ * tool to a web client through the relay server.
+ */
+test.describe('CLI to Web Text Messaging', () => {
+  let relayServer;
+  let serverPort;
+  let serverUrl;
+
+  test.beforeAll(async () => {
+    // Start the relay server
+    serverPort = 8082 + Math.floor(Math.random() * 1000); // Random port to avoid conflicts
+
+    return new Promise((resolve, reject) => {
+      relayServer = spawn('./e2ecp', ['serve', '--port', serverPort.toString()], {
+        cwd: path.join(__dirname, '..'),
+      });
+
+      let started = false;
+
+      relayServer.stdout.on('data', (data) => {
+        console.log(`Server: ${data}`);
+        if (!started && data.toString().includes('Starting')) {
+          started = true;
+          serverUrl = `http://localhost:${serverPort}`;
+          // Give server more time to fully initialize WebSocket handlers
+          setTimeout(resolve, 3000);
+        }
+      });
+
+      relayServer.stderr.on('data', (data) => {
+        console.error(`Server Error: ${data}`);
+      });
+
+      relayServer.on('error', (error) => {
+        reject(error);
+      });
+
+      // Timeout in case server doesn't start
+      setTimeout(() => {
+        if (!started) {
+          started = true;
+          serverUrl = `http://localhost:${serverPort}`;
+          resolve();
+        }
+      }, 5000);
+    });
+  });
+
+  test.afterAll(async () => {
+    // Stop the relay server and wait for cleanup
+    if (relayServer) {
+      relayServer.kill('SIGTERM');
+      // Wait for server to fully shutdown
+      await new Promise(resolve => setTimeout(resolve, 2000));
+    }
+  });
+
+  test('should send text message from CLI to web receiver', async ({ browser }) => {
+    const testMessage = 'Hello from CLI! This is a text message sent from command line.';
+    const context = await browser.newContext();
+    const page = await context.newPage();
+
+    try {
+      // Generate a unique room name
+      const roomName = `test-cli-web-text-${Date.now()}`;
+
+      // Navigate web receiver to the room first
+      await page.goto(`${serverUrl}/${roomName}`, { waitUntil: 'networkidle', timeout: 30000 });
+
+      // Wait for the page to be ready
+      await page.waitForSelector('button:has-text("CLICK OR DROP FILES HERE"), div:has-text("WAITING FOR PEER")', { timeout: 15000 });
+
+      // Extra wait to ensure WebSocket connection is established
+      await new Promise(resolve => setTimeout(resolve, 2000));
+
+      // Start CLI sender
+      const wsUrl = `ws://localhost:${serverPort}`;
+      const cliSender = spawn('./e2ecp', ['send', testMessage, roomName, '--server', wsUrl], {
+        cwd: path.join(__dirname, '..'),
+      });
+
+      let senderOutput = '';
+
+      cliSender.stdout.on('data', (data) => {
+        senderOutput += data.toString();
+        console.log(`CLI Sender: ${data}`);
+      });
+
+      cliSender.stderr.on('data', (data) => {
+        console.error(`CLI Sender Error: ${data}`);
+      });
+
+      // Web receiver: Wait for the text message to appear
+      await page.waitForSelector(`text=${testMessage}`, { timeout: 15000 });
+
+      // Verify the message is displayed
+      const messageBox = await page.locator('.bg-white.border-2').filter({ hasText: testMessage });
+      await expect(messageBox).toBeVisible();
+
+      // Verify copy button exists
+      const copyButton = await messageBox.locator('button i.fa-copy');
+      await expect(copyButton).toBeVisible();
+
+      // Verify the message content
+      const messageText = await messageBox.locator('div.whitespace-pre-wrap').textContent();
+      expect(messageText.trim()).toBe(testMessage);
+
+      // Wait for CLI sender to complete
+      await new Promise((resolve) => {
+        cliSender.on('close', (code) => {
+          console.log(`CLI Sender exited with code ${code}`);
+          resolve();
+        });
+      });
+
+      console.log('CLI Sender output:', senderOutput);
+
+    } finally {
+      await page.close();
+      await context.close();
+    }
+  });
+});

--- a/tests/web-to-cli-text.spec.js
+++ b/tests/web-to-cli-text.spec.js
@@ -1,0 +1,153 @@
+// @ts-check
+const { test, expect } = require('@playwright/test');
+const path = require('path');
+const { spawn } = require('child_process');
+
+/**
+ * Test: Web to CLI text message transfer
+ *
+ * This test verifies that a text message can be successfully sent from a web client
+ * to the command-line tool through the relay server.
+ */
+test.describe('Web to CLI Text Messaging', () => {
+  let relayServer;
+  let serverPort;
+  let serverUrl;
+
+  test.beforeAll(async () => {
+    // Start the relay server
+    serverPort = 8083 + Math.floor(Math.random() * 1000); // Random port to avoid conflicts
+
+    return new Promise((resolve, reject) => {
+      relayServer = spawn('./e2ecp', ['serve', '--port', serverPort.toString()], {
+        cwd: path.join(__dirname, '..'),
+      });
+
+      let started = false;
+
+      relayServer.stdout.on('data', (data) => {
+        console.log(`Server: ${data}`);
+        if (!started && data.toString().includes('Starting')) {
+          started = true;
+          serverUrl = `http://localhost:${serverPort}`;
+          // Give server more time to fully initialize WebSocket handlers
+          setTimeout(resolve, 3000);
+        }
+      });
+
+      relayServer.stderr.on('data', (data) => {
+        console.error(`Server Error: ${data}`);
+      });
+
+      relayServer.on('error', (error) => {
+        reject(error);
+      });
+
+      // Timeout in case server doesn't start
+      setTimeout(() => {
+        if (!started) {
+          started = true;
+          serverUrl = `http://localhost:${serverPort}`;
+          resolve();
+        }
+      }, 5000);
+    });
+  });
+
+  test.afterAll(async () => {
+    // Stop the relay server and wait for cleanup
+    if (relayServer) {
+      relayServer.kill('SIGTERM');
+      // Wait for server to fully shutdown
+      await new Promise(resolve => setTimeout(resolve, 2000));
+    }
+  });
+
+  test('should send text message from web to CLI receiver', async ({ browser }) => {
+    const testMessage = 'Hello from Web! This is a text message sent from the browser.';
+    const context = await browser.newContext();
+    const page = await context.newPage();
+
+    try {
+      // Generate a unique room name
+      const roomName = `test-web-cli-text-${Date.now()}`;
+      const wsUrl = `ws://localhost:${serverPort}`;
+
+      // Create a temp directory for CLI receiver
+      const tmpDir = path.join(__dirname, 'tmp-web-cli-text');
+      const fs = require('fs');
+      if (!fs.existsSync(tmpDir)) {
+        fs.mkdirSync(tmpDir, { recursive: true });
+      }
+
+      // Start CLI receiver
+      const cliReceiver = spawn('./e2ecp', ['receive', roomName, '--server', wsUrl, '-o', tmpDir, '-f'], {
+        cwd: path.join(__dirname, '..'),
+      });
+
+      let receiverOutput = '';
+      let textReceived = false;
+
+      cliReceiver.stdout.on('data', (data) => {
+        receiverOutput += data.toString();
+        console.log(`CLI Receiver: ${data}`);
+        // Check if the text message was received
+        if (data.toString().includes('Received text message')) {
+          textReceived = true;
+        }
+      });
+
+      cliReceiver.stderr.on('data', (data) => {
+        console.error(`CLI Receiver Error: ${data}`);
+      });
+
+      // Wait for CLI receiver to connect
+      await new Promise(resolve => setTimeout(resolve, 3000));
+
+      // Navigate web sender to the room
+      await page.goto(`${serverUrl}/${roomName}`, { waitUntil: 'networkidle', timeout: 30000 });
+
+      // Wait for both clients to be connected (text input should be enabled)
+      await page.waitForSelector('input[placeholder="TYPE TEXT TO SEND..."]:not([disabled])', { timeout: 15000 });
+
+      // Extra wait to ensure connection is stable
+      await new Promise(resolve => setTimeout(resolve, 1000));
+
+      // Web sender: Type text message
+      const textInput = await page.locator('input[placeholder="TYPE TEXT TO SEND..."]');
+      await textInput.fill(testMessage);
+
+      // Web sender: Click send button
+      await page.click('button:has-text("SEND")');
+
+      // Wait for CLI receiver to process the message
+      await new Promise(resolve => setTimeout(resolve, 3000));
+
+      // Verify the message was received by CLI
+      expect(textReceived).toBe(true);
+      expect(receiverOutput).toContain(testMessage);
+
+      // Clean up CLI receiver
+      cliReceiver.kill('SIGTERM');
+
+      // Wait for CLI receiver to close
+      await new Promise((resolve) => {
+        cliReceiver.on('close', (code) => {
+          console.log(`CLI Receiver exited with code ${code}`);
+          resolve();
+        });
+      });
+
+      console.log('CLI Receiver output:', receiverOutput);
+
+      // Clean up temp directory
+      if (fs.existsSync(tmpDir)) {
+        fs.rmSync(tmpDir, { recursive: true, force: true });
+      }
+
+    } finally {
+      await page.close();
+      await context.close();
+    }
+  });
+});

--- a/tests/web-to-web-text.spec.js
+++ b/tests/web-to-web-text.spec.js
@@ -1,0 +1,180 @@
+// @ts-check
+const { test, expect } = require('@playwright/test');
+const path = require('path');
+const { spawn } = require('child_process');
+
+/**
+ * Test: Web to Web text message transfer
+ *
+ * This test verifies that two browser clients can successfully send and receive
+ * text messages through the relay server using end-to-end encryption.
+ */
+test.describe('Web to Web Text Messaging', () => {
+  let relayServer;
+  let serverPort;
+  let serverUrl;
+
+  test.beforeAll(async () => {
+    // Start the relay server
+    serverPort = 8080 + Math.floor(Math.random() * 1000); // Random port to avoid conflicts
+
+    return new Promise((resolve, reject) => {
+      relayServer = spawn('./e2ecp', ['serve', '--port', serverPort.toString()], {
+        cwd: path.join(__dirname, '..'),
+      });
+
+      let started = false;
+
+      relayServer.stdout.on('data', (data) => {
+        console.log(`Server: ${data}`);
+        if (!started && data.toString().includes('Starting')) {
+          started = true;
+          serverUrl = `http://localhost:${serverPort}`;
+          // Give server more time to fully initialize WebSocket handlers
+          setTimeout(resolve, 3000);
+        }
+      });
+
+      relayServer.stderr.on('data', (data) => {
+        console.error(`Server Error: ${data}`);
+      });
+
+      relayServer.on('error', (error) => {
+        reject(error);
+      });
+
+      // Timeout in case server doesn't start
+      setTimeout(() => {
+        if (!started) {
+          started = true;
+          serverUrl = `http://localhost:${serverPort}`;
+          resolve();
+        }
+      }, 5000);
+    });
+  });
+
+  test.afterAll(async () => {
+    // Stop the relay server and wait for cleanup
+    if (relayServer) {
+      relayServer.kill('SIGTERM');
+      // Wait for server to fully shutdown
+      await new Promise(resolve => setTimeout(resolve, 2000));
+    }
+  });
+
+  test('should send text message from one web client to another', async ({ browser }) => {
+    const testMessage = 'Hello from Playwright! This is a test text message.';
+
+    // Create two browser contexts (sender and receiver)
+    const senderContext = await browser.newContext();
+    const receiverContext = await browser.newContext();
+
+    const senderPage = await senderContext.newPage();
+    const receiverPage = await receiverContext.newPage();
+
+    try {
+      // Generate a unique room name
+      const roomName = `text-test-room-${Date.now()}`;
+
+      // Navigate receiver first and wait for it to be ready
+      await receiverPage.goto(`${serverUrl}/${roomName}`, { waitUntil: 'networkidle', timeout: 30000 });
+
+      // Wait a bit for receiver's WebSocket connection to establish
+      await new Promise(resolve => setTimeout(resolve, 2000));
+
+      // Now navigate sender
+      await senderPage.goto(`${serverUrl}/${roomName}`, { waitUntil: 'networkidle', timeout: 30000 });
+
+      // Wait for both clients to be connected (text input should be enabled)
+      await senderPage.waitForSelector('input[placeholder="TYPE TEXT TO SEND..."]:not([disabled])', { timeout: 15000 });
+      await receiverPage.waitForSelector('input[placeholder="TYPE TEXT TO SEND..."]:not([disabled])', { timeout: 15000 });
+
+      // Extra wait to ensure connection is stable
+      await new Promise(resolve => setTimeout(resolve, 1000));
+
+      // Sender: Type text message
+      const textInput = await senderPage.locator('input[placeholder="TYPE TEXT TO SEND..."]');
+      await textInput.fill(testMessage);
+
+      // Sender: Click send button
+      await senderPage.click('button:has-text("SEND")');
+
+      // Receiver: Wait for the text message to appear
+      await receiverPage.waitForSelector(`text=${testMessage}`, { timeout: 10000 });
+
+      // Verify the message is displayed with copy button
+      const messageBox = await receiverPage.locator('.bg-white.border-2').filter({ hasText: testMessage });
+      await expect(messageBox).toBeVisible();
+
+      // Verify copy button exists
+      const copyButton = await messageBox.locator('button i.fa-copy');
+      await expect(copyButton).toBeVisible();
+
+      // Verify the message content
+      const messageText = await messageBox.locator('div.whitespace-pre-wrap').textContent();
+      expect(messageText.trim()).toBe(testMessage);
+
+      // Test copy functionality
+      await messageBox.locator('button').click();
+
+      // Wait a bit for clipboard operation
+      await new Promise(resolve => setTimeout(resolve, 500));
+
+    } finally {
+      await senderPage.close();
+      await receiverPage.close();
+      await senderContext.close();
+      await receiverContext.close();
+    }
+  });
+
+  test('should send text message with Enter key', async ({ browser }) => {
+    const testMessage = 'Testing Enter key to send!';
+
+    // Create two browser contexts (sender and receiver)
+    const senderContext = await browser.newContext();
+    const receiverContext = await browser.newContext();
+
+    const senderPage = await senderContext.newPage();
+    const receiverPage = await receiverContext.newPage();
+
+    try {
+      // Generate a unique room name
+      const roomName = `text-enter-test-${Date.now()}`;
+
+      // Navigate receiver first and wait for it to be ready
+      await receiverPage.goto(`${serverUrl}/${roomName}`, { waitUntil: 'networkidle', timeout: 30000 });
+
+      // Wait a bit for receiver's WebSocket connection to establish
+      await new Promise(resolve => setTimeout(resolve, 2000));
+
+      // Now navigate sender
+      await senderPage.goto(`${serverUrl}/${roomName}`, { waitUntil: 'networkidle', timeout: 30000 });
+
+      // Wait for both clients to be connected
+      await senderPage.waitForSelector('input[placeholder="TYPE TEXT TO SEND..."]:not([disabled])', { timeout: 15000 });
+
+      // Extra wait to ensure connection is stable
+      await new Promise(resolve => setTimeout(resolve, 1000));
+
+      // Sender: Type text message and press Enter
+      const textInput = await senderPage.locator('input[placeholder="TYPE TEXT TO SEND..."]');
+      await textInput.fill(testMessage);
+      await textInput.press('Enter');
+
+      // Receiver: Wait for the text message to appear
+      await receiverPage.waitForSelector(`text=${testMessage}`, { timeout: 10000 });
+
+      // Verify the message is displayed
+      const messageBox = await receiverPage.locator('.bg-white.border-2').filter({ hasText: testMessage });
+      await expect(messageBox).toBeVisible();
+
+    } finally {
+      await senderPage.close();
+      await receiverPage.close();
+      await senderContext.close();
+      await receiverContext.close();
+    }
+  });
+});

--- a/web/src/App.jsx
+++ b/web/src/App.jsx
@@ -653,7 +653,7 @@ export default function App() {
             if (msg.type === "peer_disconnected") {
                 const disconnectedPeerName = msg.mnemonic || msg.peerId || "Peer";
                 log(`${disconnectedPeerName} disconnected`);
-                
+
                 // Show disconnection notification with peer's icons
                 const peerIcons = mnemonicToIcons(disconnectedPeerName);
                 toast.error(
@@ -665,24 +665,20 @@ export default function App() {
                     </div>,
                     { duration: 4000 }
                 );
-                
-                // Reset peer state
+
+                // Reset peer state but keep connection and received data
+                // This allows waiting for a new peer without losing received texts/files
                 setPeerMnemonic(null);
                 havePeerPubRef.current = false;
                 aesKeyRef.current = null;
                 setHasAesKey(false);
-                
-                // Close current connection
-                if (wsRef.current) {
-                    wsRef.current.close();
-                }
-                
-                // Rejoin the same room after a short delay
-                setTimeout(() => {
-                    log(`Rejoining room ${roomId}`);
-                    connectToRoom();
-                }, 500);
-                
+
+                // Update status to show waiting for new peer
+                setStatus(`Connected as ${myMnemonicRef.current || "waiting..."}`);
+                setPeerCount(1);
+
+                // DON'T close connection or rejoin - stay connected and preserve received data
+
                 return;
             }
             


### PR DESCRIPTION
This commit adds the ability to send and receive text messages in addition to files and folders.

Changes:
- CLI: Modified send command to detect if input is a file/folder or text
  - If input path doesn't exist, it's sent as text
  - Added SendText function in src/client/sendtext.go
  - Updated receive.go to handle text_message type
  - Text messages are encrypted with AES-GCM like file metadata

- Web: Added text input field below file transfer area
  - Input field with SEND button
  - Received texts displayed with copy button
  - Encrypted text messages using same crypto as files
  - Toast notifications for send/receive events

- Tests:
  - Added Go integration test for CLI<->CLI text messaging
  - Added Playwright e2e test for web<->web text messaging
  - Added Playwright e2e test for CLI<->web text messaging
  - Added Playwright e2e test for web<->CLI text messaging

Implementation details:
- Reuses existing protobuf encrypted_metadata/metadata_iv fields
- New message type "text_message" for sending text
- New message type "text_received" for acknowledgment
- Text is encrypted end-to-end like all other data
- CLI prints received text with decorative borders
- Web displays received text in styled boxes with copy button