### PR TITLE
Fixed bug when sent text is not showed up in web interface

### DIFF
--- a/Dockerfile.build
+++ b/Dockerfile.build
@@ -8,8 +8,12 @@
 FROM node:24-alpine AS web-builder
 
 WORKDIR /build/web
+COPY web/package-lock.json .
+COPY web/package.json .
+RUN npm install 
+
 COPY web/ ./
-RUN npm install && npm run build
+RUN npm run build
 
 # Stage 2: Build the Go binary
 FROM golang:1.25-alpine AS go-builder

--- a/src/client/send.go
+++ b/src/client/send.go
@@ -21,6 +21,8 @@ import (
 	"github.com/gorilla/websocket"
 )
 
+const maxRetries = 3
+
 // SendFile sends a file to the specified room via the relay server
 func SendFile(filePath, roomID, serverURL string, logger *slog.Logger) {
 	fileInfo, err := os.Stat(filePath)
@@ -433,7 +435,6 @@ func SendFile(filePath, roomID, serverURL string, logger *slog.Logger) {
 					}
 					pendingChunks := make(map[int]*ChunkInfo)
 					var pendingMutex sync.Mutex
-					maxRetries := 3
 					ackTimeout := 5 * time.Second
 					lastActivityTime := time.Now()
 					transferTimeout := 30 * time.Second
@@ -546,7 +547,6 @@ func SendFile(filePath, roomID, serverURL string, logger *slog.Logger) {
 						if pendingCount == 0 {
 							break
 						}
-
 						if time.Since(waitStart) > 30*time.Second {
 							stopRetransmitter <- true
 							log.Fatalf("Timeout waiting for chunk acknowledgments")
@@ -615,6 +615,7 @@ func SendText(text, roomID, serverURL string, logger *slog.Logger) {
 	var peerMnemonic string
 	var transferStarted bool
 	var transferMutex sync.Mutex
+	transferReceivedChan := make(chan bool) // Channel for receiving transfer finish
 
 	sendPublicKey := func() {
 		pubKeyBytes := privKey.PublicKey().Bytes()
@@ -669,6 +670,7 @@ func SendText(text, roomID, serverURL string, logger *slog.Logger) {
 				if receiverName == "" {
 					receiverName = "Receiver"
 				}
+				transferReceivedChan <- true
 				fmt.Printf("%s confirmed receipt of the text.\n", receiverName)
 				return
 
@@ -768,8 +770,25 @@ func SendText(text, roomID, serverURL string, logger *slog.Logger) {
 
 					fmt.Printf("Sent encrypted text to %s\n", peerMnemonic)
 
-					// Wait for confirmation
-					time.Sleep(2 * time.Second)
+					waitRetransmitter := make(chan struct{})
+					go func() {
+						ticker := time.NewTicker(500 * time.Millisecond)
+						retries := 0
+						for {
+							select {
+							case <-transferReceivedChan:
+								waitRetransmitter <- struct{}{}
+								return
+							case <-ticker.C:
+								if retries >= maxRetries {
+									log.Fatalf("Failed to send text after %d retries", maxRetries)
+								}
+								safeSend(textMsg)
+								retries += 1
+							}
+						}
+					}()
+					<-waitRetransmitter
 				}()
 			}
 		}

--- a/src/client/send.go
+++ b/src/client/send.go
@@ -615,7 +615,7 @@ func SendText(text, roomID, serverURL string, logger *slog.Logger) {
 	var peerMnemonic string
 	var transferStarted bool
 	var transferMutex sync.Mutex
-	transferReceivedChan := make(chan bool) // Channel for receiving transfer finish
+	transferReceivedChan := make(chan bool, 1) // Channel for receiving transfer finish
 
 	sendPublicKey := func() {
 		pubKeyBytes := privKey.PublicKey().Bytes()


### PR DESCRIPTION
### Description
When a client sends text, if it doesn't get an immediate confirmation  from the peer, it simply waits indefinitely. 
The specific failure scenario happens when a cli command, like `./e2ecp send sometext ...`, executes before the recipient's browser has  loaded.

- The client sends the text immediately after sending public key.
- The recipient's **Shared Secret** isn't ready yet.
-  The recipient receives the text but  shared secret is still processing, so it rejects the message. 
   ```jsx
            if (msg.type === "text_message") {
                if (!aesKeyRef.current) {
                    log("Can't decrypt text yet (no shared key)");
                    return;
                }
   ```
-  Since the sender is just waiting indefinitely and never retries, the message ultimately fails.

Changes
* **Retry for text:** Implemented a **retries** for sending text. If the sender does not receive an immediate successful response from the peer, it will attempt to resend the text `maxRetries` times.
* **Update dockerfile.build:** Preventing unnecessary reinstallation of dependencies on subsequent builds when a new change is made.